### PR TITLE
feat: allow configuring optimizer search space via workflow config

### DIFF
--- a/tests/nat/data_models/test_optimizable.py
+++ b/tests/nat/data_models/test_optimizable.py
@@ -76,6 +76,16 @@ class TestOptimizableField:
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
 
+    def test_space_optional(self):
+
+        class M(BaseModel):
+            x: int = OptimizableField(5)
+
+        m = M()
+        extras = dict(m.model_fields)["x"].json_schema_extra
+        assert extras["optimizable"] is True
+        assert "search_space" not in extras
+
     def test_preserves_user_extras_and_merges(self):
         space = SearchSpace(low=["red", "blue"], high=None)
 
@@ -183,9 +193,11 @@ class TestOptimizableMixin:
 
         m = MyModel()
         assert m.optimizable_params == []
+        assert m.search_space == {}
 
-        m2 = MyModel(optimizable_params=["a"])
+        m2 = MyModel(optimizable_params=["a"], search_space={"a": SearchSpace(low=0, high=1)})
         assert m2.optimizable_params == ["a"]
+        assert "a" in m2.search_space and m2.search_space["a"].low == 0
 
     def test_schema_contains_description(self):
 

--- a/tests/nat/profiler/test_optimizable_utils.py
+++ b/tests/nat/profiler/test_optimizable_utils.py
@@ -85,6 +85,42 @@ def test_walk_optimizables_warns_when_no_allowlist(caplog: pytest.LogCaptureFixt
     assert isinstance(spaces["a"], SearchSpace)
 
 
+def test_walk_optimizables_uses_search_space_overrides():
+
+    class MyModel(OptimizableMixin):
+        a: float = 0.1
+
+    cfg = MyModel(optimizable_params=["a"], search_space={"a": SearchSpace(low=0, high=1)})
+
+    spaces = walk_optimizables(cfg)
+
+    assert "a" in spaces
+    assert spaces["a"].low == 0 and spaces["a"].high == 1
+
+
+def test_walk_optimizables_requires_search_space():
+
+    class MyModel(OptimizableMixin):
+        a: int = OptimizableField(0)
+
+    cfg = MyModel(optimizable_params=["a"])
+
+    with pytest.raises(ValueError, match="no search space"):
+        walk_optimizables(cfg)
+
+
+def test_walk_optimizables_can_mark_without_space_in_code():
+
+    class MyModel(OptimizableMixin):
+        a: int = OptimizableField(0)
+
+    cfg = MyModel(optimizable_params=["a"], search_space={"a": SearchSpace(low=0, high=1)})
+
+    spaces = walk_optimizables(cfg)
+
+    assert "a" in spaces and spaces["a"].low == 0
+
+
 def test_static_type_fallback_for_dict_of_models():
 
     class Item(BaseModel):


### PR DESCRIPTION
## Summary
- allow marking fields as optimizable without specifying a `SearchSpace` in code
- raise a clear error when a field is marked optimizable but no search space is provided
- document supplying search spaces from workflow config and warn when missing

## Testing
- `PYTHONPATH=/tmp:. pytest tests/nat/data_models/test_optimizable.py tests/nat/profiler/test_optimizable_utils.py -q`
- `PYTHONPATH=/tmp:. pytest tests/nat/profiler/test_parameter_optimizer.py -q`
- `PYTHONPATH=/tmp:. pytest tests/nat/profiler/test_prompt_optimizer.py::test_optimize_prompts_happy_path_without_recombine -q`
- `pre-commit run --files docs/source/reference/optimizer.md src/nat/data_models/optimizable.py src/nat/profiler/parameter_optimization/optimizable_utils.py tests/nat/data_models/test_optimizable.py tests/nat/profiler/test_optimizable_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1e481012883279e4adfc8dabe87a4