### PR TITLE
Refactor function intercepts to use middleware pattern

### DIFF
--- a/src/nat/intercepts/__init__.py
+++ b/src/nat/intercepts/__init__.py
@@ -4,19 +4,19 @@
 """Function intercept implementations for NeMo Agent Toolkit."""
 
 from nat.intercepts.cache_intercept import CacheIntercept
+from nat.intercepts.function_intercept import CallNext
+from nat.intercepts.function_intercept import CallNextStream
 from nat.intercepts.function_intercept import FunctionIntercept
 from nat.intercepts.function_intercept import FunctionInterceptChain
 from nat.intercepts.function_intercept import FunctionInterceptContext
-from nat.intercepts.function_intercept import SingleInvokeCallable
-from nat.intercepts.function_intercept import StreamInvokeCallable
 from nat.intercepts.function_intercept import validate_intercepts
 
 __all__ = [
     "CacheIntercept",
+    "CallNext",
+    "CallNextStream",
     "FunctionIntercept",
     "FunctionInterceptChain",
     "FunctionInterceptContext",
-    "SingleInvokeCallable",
-    "StreamInvokeCallable",
     "validate_intercepts",
 ]

--- a/src/nat/intercepts/cache_intercept.py
+++ b/src/nat/intercepts/cache_intercept.py
@@ -1,6 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Cache middleware for function memoization with similarity matching.
 
 This module provides a cache middleware that memoizes function calls based on
@@ -143,8 +154,7 @@ class CacheIntercept(FunctionIntercept):
 
         return best_match
 
-    async def intercept_invoke(self, value: Any, call_next: CallNext,
-                               context: FunctionInterceptContext) -> Any:
+    async def intercept_invoke(self, value: Any, call_next: CallNext, context: FunctionInterceptContext) -> Any:
         """Cache middleware for single-output invocations.
 
         Implements the four-phase middleware pattern:

--- a/src/nat/intercepts/cache_intercept.py
+++ b/src/nat/intercepts/cache_intercept.py
@@ -1,11 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Cache intercept for function memoization with similarity matching.
+"""Cache middleware for function memoization with similarity matching.
 
-This module provides a cache intercept that can memoize function calls based on
-input similarity. It supports exact matching for maximum performance and fuzzy
-matching using Python's built-in difflib for similarity computation.
+This module provides a cache middleware that memoizes function calls based on
+input similarity. It demonstrates the middleware pattern by:
+
+1. Preprocessing: Serializing and checking the cache for similar inputs
+2. Calling next: Delegating to the next middleware/function if no cache hit
+3. Postprocessing: Caching the result for future use
+4. Continuing: Returning the result (cached or fresh)
+
+The cache supports exact matching for maximum performance and fuzzy matching
+using Python's built-in difflib for similarity computation.
 """
 
 from __future__ import annotations
@@ -17,21 +24,28 @@ from typing import Any
 
 from nat.builder.context import Context
 from nat.builder.context import ContextState
+from nat.intercepts.function_intercept import CallNext
+from nat.intercepts.function_intercept import CallNextStream
 from nat.intercepts.function_intercept import FunctionIntercept
 from nat.intercepts.function_intercept import FunctionInterceptContext
-from nat.intercepts.function_intercept import SingleInvokeCallable
-from nat.intercepts.function_intercept import StreamInvokeCallable
 
 logger = logging.getLogger(__name__)
 
 
 class CacheIntercept(FunctionIntercept):
-    """Cache function outputs based on input similarity.
+    """Cache middleware that memoizes function outputs based on input similarity.
 
-    This intercept serializes function inputs to strings and performs
-    similarity matching against previously seen inputs. If a similar input
-    is found above the configured threshold, it returns the cached output
-    instead of calling the function.
+    This middleware demonstrates the four-phase middleware pattern:
+
+    1. **Preprocess**: Serialize input and check cache for similar entries
+    2. **Call Next**: Delegate to next middleware/function if cache miss
+    3. **Postprocess**: Store the result in cache for future use
+    4. **Continue**: Return the result (from cache or fresh)
+
+    The cache serializes function inputs to strings and performs similarity
+    matching against previously seen inputs. If a similar input is found above
+    the configured threshold, it returns the cached output without calling the
+    next middleware or function.
 
     Args:
         enabled_mode: Either "always" to always cache, or "eval" to only
@@ -129,57 +143,87 @@ class CacheIntercept(FunctionIntercept):
 
         return best_match
 
-    async def intercept_invoke(self, value: Any, next_call: SingleInvokeCallable,
+    async def intercept_invoke(self, value: Any, call_next: CallNext,
                                context: FunctionInterceptContext) -> Any:
-        """Intercept single-output invocations with caching logic.
+        """Cache middleware for single-output invocations.
 
-        This method:
-        1. Checks if caching should be enabled
-        2. Serializes the input
-        3. Looks for similar cached inputs
-        4. Returns cached output if found, otherwise delegates to function
-        5. Caches the output for future use
+        Implements the four-phase middleware pattern:
+
+        1. **Preprocess**: Check if caching is enabled and serialize input
+        2. **Call Next**: Delegate to next middleware/function if cache miss
+        3. **Postprocess**: Store the result in cache
+        4. **Continue**: Return the result (cached or fresh)
+
+        Args:
+            value: The input value to process
+            call_next: Callable to invoke the next middleware or function
+            context: Metadata about the function being intercepted
+
+        Returns:
+            The cached output if found, otherwise the fresh output
         """
-        # Check if we should cache
+        # Phase 1: Preprocess - check if caching should be enabled
         if not self._should_cache():
-            return await next_call(value)
+            return await call_next(value)
 
-        # Try to serialize the input
+        # Phase 1: Preprocess - serialize the input
         input_str = self._serialize_input(value)
         if input_str is None:
-            # Can't serialize, pass through to function
+            # Can't serialize, pass through to next middleware/function
             logger.debug("Could not serialize input for function %s, bypassing cache", context.name)
-            return await next_call(value)
+            return await call_next(value)
 
-        # Look for a similar cached input
+        # Phase 1: Preprocess - look for a similar cached input
         similar_key = self._find_similar_key(input_str)
         if similar_key is not None:
-            # Found a match, return the cached output
+            # Cache hit - short-circuit and return cached output
             logger.debug("Cache hit for function %s with similarity %.2f",
                          context.name,
                          1.0 if similar_key == input_str else self._similarity_threshold)
+            # Phase 4: Continue - return cached result
             return self._cache[similar_key]
 
-        # No match found, call the function
+        # Phase 2: Call next - no cache hit, call next middleware/function
         logger.debug("Cache miss for function %s", context.name)
-        result = await next_call(value)
+        result = await call_next(value)
 
-        # Cache the result
+        # Phase 3: Postprocess - cache the result for future use
         self._cache[input_str] = result
         logger.debug("Cached result for function %s", context.name)
 
+        # Phase 4: Continue - return the fresh result
         return result
 
-    async def intercept_stream(self, value: Any, next_call: StreamInvokeCallable,
+    async def intercept_stream(self, value: Any, call_next: CallNextStream,
                                context: FunctionInterceptContext) -> AsyncIterator[Any]:
-        """Intercept streaming invocations - always delegates to function.
+        """Cache middleware for streaming invocations - bypasses caching.
 
         Streaming results are not cached as they would need to be buffered
-        entirely in memory, defeating the purpose of streaming.
+        entirely in memory, which would defeat the purpose of streaming.
+
+        This method demonstrates the middleware pattern for streams:
+
+        1. **Preprocess**: Log that we're bypassing cache
+        2. **Call Next**: Get stream from next middleware/function
+        3. **Process Chunks**: Yield each chunk as it arrives
+        4. **Continue**: Complete the stream
+
+        Args:
+            value: The input value to process
+            call_next: Callable to invoke the next middleware or function stream
+            context: Metadata about the function being intercepted
+
+        Yields:
+            Chunks from the stream (unmodified)
         """
+        # Phase 1: Preprocess - log that we're bypassing cache for streams
         logger.debug("Streaming call for function %s, bypassing cache", context.name)
-        async for chunk in next_call(value):
+
+        # Phase 2-3: Call next and process chunks - yield chunks as they arrive
+        async for chunk in call_next(value):
             yield chunk
+
+        # Phase 4: Continue - stream is complete (implicit)
 
 
 __all__ = ["CacheIntercept"]

--- a/src/nat/intercepts/function_intercept.py
+++ b/src/nat/intercepts/function_intercept.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Middleware-style function intercepts for the NeMo Agent toolkit.
 
 This module provides a middleware pattern for function intercepts, allowing you to
@@ -37,12 +49,8 @@ CallNext = Callable[[Any], Awaitable[Any]]
 CallNextStream = Callable[[Any], AsyncIterator[Any]]
 """Callable signature for calling the next middleware in the chain (streaming)."""
 
-# Legacy aliases for backward compatibility
 SingleInvokeCallable = CallNext
-"""Deprecated: Use CallNext instead."""
-
 StreamInvokeCallable = CallNextStream
-"""Deprecated: Use CallNextStream instead."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -107,8 +115,7 @@ class FunctionIntercept(ABC):
 
         return self._is_final
 
-    async def intercept_invoke(self, value: Any, call_next: CallNext,
-                               context: FunctionInterceptContext) -> Any:
+    async def intercept_invoke(self, value: Any, call_next: CallNext, context: FunctionInterceptContext) -> Any:
         """Middleware for single-output invocations.
 
         Args:
@@ -264,7 +271,7 @@ __all__ = [
     "FunctionIntercept",
     "FunctionInterceptChain",
     "FunctionInterceptContext",
-    "SingleInvokeCallable",  # Deprecated, use CallNext
-    "StreamInvokeCallable",  # Deprecated, use CallNextStream
+    "SingleInvokeCallable",
+    "StreamInvokeCallable",
     "validate_intercepts",
 ]

--- a/src/nat/intercepts/function_intercept.py
+++ b/src/nat/intercepts/function_intercept.py
@@ -49,9 +49,6 @@ CallNext = Callable[[Any], Awaitable[Any]]
 CallNextStream = Callable[[Any], AsyncIterator[Any]]
 """Callable signature for calling the next middleware in the chain (streaming)."""
 
-SingleInvokeCallable = CallNext
-StreamInvokeCallable = CallNextStream
-
 
 @dataclasses.dataclass(frozen=True)
 class FunctionInterceptContext:
@@ -271,7 +268,5 @@ __all__ = [
     "FunctionIntercept",
     "FunctionInterceptChain",
     "FunctionInterceptContext",
-    "SingleInvokeCallable",
-    "StreamInvokeCallable",
     "validate_intercepts",
 ]

--- a/src/nat/intercepts/function_intercept.py
+++ b/src/nat/intercepts/function_intercept.py
@@ -1,17 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Helpers for configuring per-function intercept chains.
+"""Middleware-style function intercepts for the NeMo Agent toolkit.
 
-This module introduces the :class:`FunctionIntercept` ABC alongside utility
-structures that allow callers to register interceptors which run before a
-function's ``ainvoke``/``astream`` logic.  Intercepts are configured at
-registration time through the ``@register_function`` decorator and are bound to
-function instances when they are constructed by the workflow builder.
+This module provides a middleware pattern for function intercepts, allowing you to
+wrap function calls with preprocessing and postprocessing logic. Intercepts work like
+middleware in web frameworks - they can modify inputs, call the next intercept in the
+chain, process outputs, and continue.
 
-Intercepts execute in the order that they are provided and can optionally be
-marked as *final*.  A final intercept terminates the chain, preventing any
-subsequent intercepts or the wrapped function from running unless the final
-intercept explicitly delegates to the next callable.
+Intercepts are configured at registration time through the ``@register_function``
+decorator and are bound to function instances when they are constructed by the
+workflow builder.
+
+Intercepts execute in the order provided and can optionally be marked as *final*.
+A final intercept terminates the chain, preventing subsequent intercepts or the
+wrapped function from running unless the final intercept explicitly delegates to
+the next callable.
 """
 
 from __future__ import annotations
@@ -28,11 +31,18 @@ from pydantic import BaseModel
 
 from nat.data_models.function import FunctionBaseConfig
 
-SingleInvokeCallable = Callable[[Any], Awaitable[Any]]
-"""Callable signature used for single-output intercept chaining."""
+CallNext = Callable[[Any], Awaitable[Any]]
+"""Callable signature for calling the next middleware in the chain (single-output)."""
 
-StreamInvokeCallable = Callable[[Any], AsyncIterator[Any]]
-"""Callable signature used for streaming intercept chaining."""
+CallNextStream = Callable[[Any], AsyncIterator[Any]]
+"""Callable signature for calling the next middleware in the chain (streaming)."""
+
+# Legacy aliases for backward compatibility
+SingleInvokeCallable = CallNext
+"""Deprecated: Use CallNext instead."""
+
+StreamInvokeCallable = CallNextStream
+"""Deprecated: Use CallNextStream instead."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -59,13 +69,33 @@ class FunctionInterceptContext:
 
 
 class FunctionIntercept(ABC):
-    """Base class for intercept implementations.
+    """Base class for middleware-style function intercepts.
+
+    Function intercepts work like middleware in web frameworks:
+
+    1. **Preprocess**: Inspect and optionally modify inputs
+    2. **Call Next**: Delegate to the next intercept or the function itself
+    3. **Postprocess**: Process, transform, or augment the output
+    4. **Continue**: Return or yield the final result
+
+    Example::
+
+        class LoggingIntercept(FunctionIntercept):
+            async def intercept_invoke(self, value, call_next, context):
+                # 1. Preprocess
+                print(f"Input: {value}")
+
+                # 2. Call next middleware/function
+                result = await call_next(value)
+
+                # 3. Postprocess
+                print(f"Output: {result}")
+
+                # 4. Continue
+                return result
 
     Concrete intercepts can override :meth:`intercept_invoke` and
-    :meth:`intercept_stream` to perform arbitrary logic before delegating to the
-    next callable in the chain.  Intercepts must preserve the function's input
-    and output schemas and should only return values that satisfy the wrapped
-    function's contracts.
+    :meth:`intercept_stream` to implement custom middleware logic.
     """
 
     def __init__(self, *, is_final: bool = False) -> None:
@@ -77,66 +107,127 @@ class FunctionIntercept(ABC):
 
         return self._is_final
 
-    async def intercept_invoke(self, value: Any, next_call: SingleInvokeCallable,
+    async def intercept_invoke(self, value: Any, call_next: CallNext,
                                context: FunctionInterceptContext) -> Any:
-        """Intercept a single-output invocation.
+        """Middleware for single-output invocations.
 
-        The default implementation simply delegates to ``next_call``.  Derived
-        classes can override this method to add behaviour before or after the
-        call, or bypass ``next_call`` entirely (for example, final intercepts).
+        Args:
+            value: The input value to process
+            call_next: Callable to invoke the next middleware or function
+            context: Metadata about the function being intercepted
+
+        Returns:
+            The (potentially modified) output from the function
+
+        The default implementation simply delegates to ``call_next``. Override this
+        to add preprocessing, postprocessing, or to short-circuit execution::
+
+            async def intercept_invoke(self, value, call_next, context):
+                # Preprocess: modify input
+                modified_input = transform(value)
+
+                # Call next: delegate to next middleware/function
+                result = await call_next(modified_input)
+
+                # Postprocess: modify output
+                modified_result = transform_output(result)
+
+                # Continue: return final result
+                return modified_result
         """
 
         del context  # Unused by the default implementation.
-        return await next_call(value)
+        return await call_next(value)
 
-    async def intercept_stream(self, value: Any, next_call: StreamInvokeCallable,
+    async def intercept_stream(self, value: Any, call_next: CallNextStream,
                                context: FunctionInterceptContext) -> AsyncIterator[Any]:
-        """Intercept a streaming invocation.
+        """Middleware for streaming invocations.
 
-        The default implementation forwards to ``next_call`` untouched.  Custom
-        intercepts can yield additional values, transform the stream, or skip
-        delegation entirely.
+        Args:
+            value: The input value to process
+            call_next: Callable to invoke the next middleware or function stream
+            context: Metadata about the function being intercepted
+
+        Yields:
+            Chunks from the stream (potentially modified)
+
+        The default implementation forwards to ``call_next`` untouched. Override this
+        to add preprocessing, transform chunks, or perform cleanup::
+
+            async def intercept_stream(self, value, call_next, context):
+                # Preprocess: setup or modify input
+                modified_input = transform(value)
+
+                # Call next: get stream from next middleware/function
+                async for chunk in call_next(modified_input):
+                    # Process each chunk
+                    modified_chunk = transform_chunk(chunk)
+                    yield modified_chunk
+
+                # Postprocess: cleanup after stream ends
+                await cleanup()
         """
 
         del context  # Unused by the default implementation.
-        async for chunk in next_call(value):
+        async for chunk in call_next(value):
             yield chunk
 
 
 class FunctionInterceptChain:
-    """Utility that composes intercept callables for a function instance."""
+    """Utility that composes middleware-style intercept callables.
+
+    This class builds a chain of middleware intercepts that execute in order,
+    with each intercept able to preprocess inputs, call the next middleware,
+    and postprocess outputs.
+    """
 
     def __init__(self, *, intercepts: Sequence[FunctionIntercept], context: FunctionInterceptContext) -> None:
         self._intercepts = tuple(intercepts)
         self._context = context
 
-    def build_single(self, final_call: SingleInvokeCallable) -> SingleInvokeCallable:
+    def build_single(self, final_call: CallNext) -> CallNext:
+        """Build the middleware chain for single-output invocations.
+
+        Args:
+            final_call: The final function to call (the actual function implementation)
+
+        Returns:
+            A callable that executes the entire middleware chain
+        """
         call = final_call
 
         for intercept in reversed(self._intercepts):
-            next_call = call
+            call_next = call
 
             async def wrapped(value: Any,
                               *,
                               _intercept: FunctionIntercept = intercept,
-                              _next_call: SingleInvokeCallable = next_call) -> Any:
-                return await _intercept.intercept_invoke(value, _next_call, self._context)
+                              _call_next: CallNext = call_next) -> Any:
+                return await _intercept.intercept_invoke(value, _call_next, self._context)
 
             call = wrapped
 
         return call
 
-    def build_stream(self, final_call: StreamInvokeCallable) -> StreamInvokeCallable:
+    def build_stream(self, final_call: CallNextStream) -> CallNextStream:
+        """Build the middleware chain for streaming invocations.
+
+        Args:
+            final_call: The final function to call (the actual function implementation)
+
+        Returns:
+            A callable that executes the entire middleware chain
+        """
         call = final_call
 
         for intercept in reversed(self._intercepts):
-            next_call = call
+            call_next = call
 
             async def wrapped(value: Any,
                               *,
                               _intercept: FunctionIntercept = intercept,
-                              _next_call: StreamInvokeCallable = next_call) -> AsyncIterator[Any]:
-                async for chunk in _intercept.intercept_stream(value, _next_call, self._context):
+                              _call_next: CallNextStream = call_next) -> AsyncIterator[Any]:
+                async for chunk in _intercept.intercept_stream(value, _call_next, self._context):
                     yield chunk
 
             call = wrapped
@@ -168,10 +259,12 @@ def validate_intercepts(intercepts: Sequence[FunctionIntercept] | None) -> tuple
 
 
 __all__ = [
+    "CallNext",
+    "CallNextStream",
     "FunctionIntercept",
     "FunctionInterceptChain",
     "FunctionInterceptContext",
-    "SingleInvokeCallable",
-    "StreamInvokeCallable",
+    "SingleInvokeCallable",  # Deprecated, use CallNext
+    "StreamInvokeCallable",  # Deprecated, use CallNextStream
     "validate_intercepts",
 ]

--- a/tests/nat/intercepts/test_cache_intercept.py
+++ b/tests/nat/intercepts/test_cache_intercept.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the CacheIntercept functionality."""
+"""Tests for the CacheIntercept middleware functionality."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This commit refactors function intercepts from a yield-based chain pattern to an explicit middleware pattern with four distinct phases:

1. Preprocess: Inspect and modify inputs before calling next
2. Call Next: Delegate to the next middleware or function
3. Postprocess: Process, transform, or augment outputs
4. Continue: Return or yield the final result

Changes:
- Updated FunctionIntercept base class with new middleware documentation
- Renamed next_call to call_next for clarity
- Added CallNext and CallNextStream type aliases (kept legacy aliases)
- Updated CacheIntercept to demonstrate the four-phase middleware pattern
- Updated all tests to use the new middleware pattern
- Comprehensively updated documentation with middleware examples
- Added detailed diagrams showing the middleware "onion" structure

The middleware pattern is more explicit about the lifecycle of intercepts and makes it clearer how preprocessing and postprocessing work together.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
