### PR TITLE
Add dependency overrides to rl_with_openpipe_art example

### DIFF
--- a/packages/nvidia_nat_openpipe_art/pyproject.toml
+++ b/packages/nvidia_nat_openpipe_art/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   # Keep sorted!!!
   "nvidia-nat~=1.4",
   "matplotlib~=3.9",
-  "openpipe-art==0.5.1"
+  "openpipe-art~=0.5.4"
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for OpenPipe ART integration in NeMo Agent toolkit"


### PR DESCRIPTION
Resolve conflict between openpipe-art (pins openai<=1.99.1) and
langchain-openai (requires openai>=1.99.9) by adding override-dependencies
directly to the example's pyproject.toml. This allows standalone installation
via `uv pip install --pre .` without needing workspace-level overrides.