### PR TITLE
Handle consecutive status check failures with retry logic in DPO trainer adapter (#1415)

### DIFF
--- a/packages/nvidia_nat_core/src/nat/profiler/decorators/latency.py
+++ b/packages/nvidia_nat_core/src/nat/profiler/decorators/latency.py
@@ -166,7 +166,18 @@ def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]
         # Import here to avoid circular dependency
         from nat.builder.context import Context
 
-        if inspect.iscoroutinefunction(func):
+        if inspect.isasyncgenfunction(func):
+            # Async generator function
+            @functools.wraps(func)
+            async def async_gen_wrapper(*args: Any, **kwargs: Any):
+                ctx = Context.get()
+                with ctx.push_latency_sensitivity(parsed_sensitivity):
+                    async for item in func(*args, **kwargs):
+                        yield item
+
+            return async_gen_wrapper  # type: ignore
+
+        elif inspect.iscoroutinefunction(func):
             # Async function
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
@@ -67,7 +67,6 @@ def fixture_sample_trie_lookup() -> PredictionTrieLookup:
 class TestDynamicPredictionTransport:
     """Tests for _DynamoTransport with dynamic prediction lookup."""
 
-    @pytest.mark.asyncio
     async def test_transport_injects_prediction_headers(self, sample_trie_lookup):
         """Test that transport overrides headers based on context predictions."""
         # Create mock base transport
@@ -116,7 +115,6 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_uses_root_fallback(self, sample_trie_lookup):
         """Test that transport falls back to root prediction for unknown paths."""
         # Create mock base transport
@@ -158,7 +156,6 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_handles_empty_context(self, sample_trie_lookup):
         """Test that transport handles missing context gracefully."""
         # Create mock base transport
@@ -197,7 +194,6 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_no_prediction_found(self):
         """Test that transport handles case where no prediction is found."""
         # Create empty trie with no predictions
@@ -240,7 +236,6 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_prediction_overrides_both_headers_and_annotations(self, sample_trie_lookup):
         """Test that predictions override both HTTP headers AND nvext.annotations."""
         # Create mock base transport

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -308,7 +308,6 @@ class TestCreateHttpxClient:
 class TestDynamoTransport:
     """Tests for _DynamoTransport custom transport wrapper."""
 
-    @pytest.mark.asyncio
     async def test_transport_injects_headers(self):
         """Test that _DynamoTransport injects HTTP headers."""
         import httpx
@@ -352,7 +351,6 @@ class TestDynamoTransport:
         # Cleanup
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_injects_nvext_annotations(self):
         """Test that _DynamoTransport injects nvext.annotations in request body."""
         import json
@@ -409,7 +407,6 @@ class TestDynamoTransport:
         # Cleanup
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_merges_existing_annotations(self):
         """Test that existing nvext.annotations are preserved (non-conflicting)."""
         import json
@@ -467,7 +464,6 @@ class TestDynamoTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_handles_non_json_gracefully(self):
         """Test that non-JSON bodies don't cause failures."""
         import httpx
@@ -504,7 +500,6 @@ class TestDynamoTransport:
 
         DynamoPrefixContext.clear()
 
-    @pytest.mark.asyncio
     async def test_transport_uses_prediction_override(self):
         """Test that prediction lookup overrides static config values."""
         import httpx

--- a/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import httpx
+
 from nat.builder.context import Context
 from nat.data_models.intermediate_step import IntermediateStepPayload
 from nat.data_models.intermediate_step import IntermediateStepType

--- a/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
@@ -27,8 +27,6 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import httpx
-import pytest
-
 from nat.builder.context import Context
 from nat.data_models.intermediate_step import IntermediateStepPayload
 from nat.data_models.intermediate_step import IntermediateStepType
@@ -94,7 +92,6 @@ def create_test_trie() -> PredictionTrieNode:
     )
 
 
-@pytest.mark.asyncio
 async def test_e2e_prediction_headers_injected_correctly():
     """Test complete flow: context tracking -> step manager -> transport -> headers."""
     # Create and save trie
@@ -190,7 +187,6 @@ async def test_e2e_prediction_headers_injected_correctly():
         DynamoPrefixContext.clear()
 
 
-@pytest.mark.asyncio
 async def test_e2e_fallback_to_root():
     """Test that unknown paths fall back to root predictions."""
     trie = create_test_trie()
@@ -240,7 +236,6 @@ async def test_e2e_fallback_to_root():
     DynamoPrefixContext.clear()
 
 
-@pytest.mark.asyncio
 async def test_e2e_multiple_calls_in_same_context():
     """Test that call tracking increments correctly for multiple LLM calls in the same function context."""
     trie = create_test_trie()

--- a/packages/nvidia_nat_core/tests/nat/llm/utils/test_thinking.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/utils/test_thinking.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from nat.llm.utils.thinking import BaseThinkingInjector
 from nat.llm.utils.thinking import FunctionArgumentWrapper
 from nat.llm.utils.thinking import patch_with_thinking
@@ -53,7 +51,6 @@ class AddThinkingWithKwargs(BaseThinkingInjector):
         return FunctionArgumentWrapper(*args, thinking=True, **kwargs)
 
 
-@pytest.mark.asyncio
 async def test_patch_with_thinking_in_place():
     args = (
         123,
@@ -91,7 +88,6 @@ async def test_patch_with_thinking_in_place():
         assert item == expected
 
 
-@pytest.mark.asyncio
 async def test_patch_with_thinking_modify_args():
     args = (
         123,
@@ -129,7 +125,6 @@ async def test_patch_with_thinking_modify_args():
         assert item == expected
 
 
-@pytest.mark.asyncio
 async def test_patch_with_thinking_modify_kwargs():
     args = (
         123,

--- a/packages/nvidia_nat_core/tests/nat/profiler/decorators/test_latency.py
+++ b/packages/nvidia_nat_core/tests/nat/profiler/decorators/test_latency.py
@@ -478,3 +478,144 @@ class TestDecoratorGeneratorFunctions:
         # Should still be able to access context after early exit
         # Note: Stack will pop when generator is garbage collected
         assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+
+
+class TestDecoratorAsyncGeneratorFunctions:
+    """Tests for @latency_sensitive decorator on async generator functions."""
+
+    async def test_async_generator_function_with_enum(self):
+        """Test decorator on async generator function with enum value."""
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def async_gen_func():
+            for i in range(3):
+                yield (i, Context.get().latency_sensitivity)
+
+        # Outside decorator, should be MEDIUM
+        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+
+        # Inside decorator, should be HIGH
+        results = [item async for item in async_gen_func()]
+        assert len(results) == 3
+        for i, sensitivity in results:
+            assert sensitivity == LatencySensitivity.HIGH
+
+        # After decorator, back to MEDIUM
+        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+
+    async def test_async_generator_function_with_string(self):
+        """Test decorator on async generator function with string value."""
+
+        @latency_sensitive("low")
+        async def async_gen_func():
+            for i in range(2):
+                yield Context.get().latency_sensitivity
+
+        results = [item async for item in async_gen_func()]
+        # LOW is in stack, but MEDIUM default has higher priority
+        assert all(s == LatencySensitivity.MEDIUM for s in results)
+
+    async def test_async_generator_function_priority_nesting(self):
+        """Test priority-based nesting with async generator functions."""
+
+        @latency_sensitive(LatencySensitivity.LOW)
+        async def low_async_gen():
+            yield Context.get().latency_sensitivity
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def high_async_gen():
+            # Get first value from low_async_gen while in HIGH context
+            async for val in low_async_gen():
+                low_result = val
+                break
+            yield Context.get().latency_sensitivity, low_result
+
+        async for outer, inner in high_async_gen():
+            # Both should be HIGH due to priority
+            assert outer == LatencySensitivity.HIGH
+            assert inner == LatencySensitivity.HIGH
+
+    async def test_async_generator_function_yields_values(self):
+        """Test that decorator preserves yielded values."""
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def async_gen_with_values(n):
+            for i in range(n):
+                yield i * 2
+
+        results = [item async for item in async_gen_with_values(4)]
+        assert results == [0, 2, 4, 6]
+
+    async def test_async_generator_function_with_args_kwargs(self):
+        """Test that decorator preserves arguments."""
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def async_gen_with_args(*args, **kwargs):
+            yield args
+            yield kwargs
+
+        results = [item async for item in async_gen_with_args(1, 2, 3, x=4, y=5)]
+        assert results[0] == (1, 2, 3)
+        assert results[1] == {"x": 4, "y": 5}
+
+    async def test_async_generator_function_exception_propagates(self):
+        """Test that exceptions propagate and stack still pops."""
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def failing_async_gen():
+            yield 1
+            raise ValueError("test error")
+
+        ctx = Context.get()
+        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+
+        agen = failing_async_gen()
+        assert await agen.__anext__() == 1
+
+        with pytest.raises(ValueError, match="test error"):
+            await agen.__anext__()
+
+        # Should revert to MEDIUM despite exception
+        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+
+    async def test_async_generator_function_early_exit(self):
+        """Test that early exit from async generator still pops stack."""
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def async_gen_func():
+            for i in range(10):
+                yield i
+
+        ctx = Context.get()
+        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+
+        # Only consume first 3 values
+        agen = async_gen_func()
+        results = []
+        for _ in range(3):
+            results.append(await agen.__anext__())
+        assert results == [0, 1, 2]
+
+        # Close async generator early
+        await agen.aclose()
+
+        # Should revert to MEDIUM after close
+        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+
+    async def test_mixed_async_and_async_gen_nesting(self):
+        """Test that async functions and async generators can nest together."""
+
+        @latency_sensitive(LatencySensitivity.LOW)
+        async def async_func():
+            return Context.get().latency_sensitivity
+
+        @latency_sensitive(LatencySensitivity.HIGH)
+        async def high_async_gen():
+            # HIGH takes precedence
+            async_result = await async_func()
+            gen_result = Context.get().latency_sensitivity
+            yield async_result, gen_result
+
+        async for async_result, gen_result in high_async_gen():
+            assert async_result == LatencySensitivity.HIGH
+            assert gen_result == LatencySensitivity.HIGH


### PR DESCRIPTION
Introduce logic to track and limit consecutive status check failures when polling job status. If the number of failures exceeds a configurable threshold, logging escalates, but regular failure handling remains unaffected.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job status monitoring to treat transient status retrieval errors as temporary, automatically retrying with exponential backoff to reduce false job failures and clearer logging.

* **New Features**
  * Added a configurable threshold for how many consecutive status check failures are tolerated before marking a job as failed.

* **Tests**
  * Expanded unit tests covering status-retry behavior, threshold bounds, and recovery scenarios.

* **Chore**
  * No changes to public API or method signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

Authors:
  - Dhruv Nandakumar (https://github.com/dnandakumar-nv)

Approvers:
  - Will Killian (https://github.com/willkill07)
  - https://github.com/mnajafian-nv

URL: https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/1415