### PR TITLE
Rename nvext.annotations to nvext.agent_hints in _DynamoTransport

### DIFF
--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -31,9 +31,9 @@ for maximum compatibility:
 1. **HTTP Headers** (``x-prefix-*``): For the generalized Thompson Sampling setup
    that uses custom ``frontend.py`` which reads headers directly.
 
-2. **nvext.annotations** (in request body): For the optimized Thompson Sampling setup
+2. **nvext.agent_hints** (in request body): For the optimized Thompson Sampling setup
    that uses the default Dynamo frontend with custom ``processor.py`` which reads
-   annotations from the preprocessed request. *This is the preferred mechanism.*
+   agent_hints from the preprocessed request. *This is the preferred mechanism.*
 
 Dynamo Prefix Parameters
 -------------------------
@@ -285,11 +285,11 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     by default using the template "nat-dynamo-{uuid}". The prefix routing parameters
     (prefix_total_requests, prefix_osl, prefix_iat) are optimizable via the NAT optimizer.
 
-    Hints are sent via both HTTP headers (``x-prefix-*``) and ``nvext.annotations``
+    Hints are sent via both HTTP headers (``x-prefix-*``) and ``nvext.agent_hints``
     in the request body for compatibility with different Dynamo setups:
 
     - **Generalized Thompson Sampling** (custom frontend.py): Reads HTTP headers
-    - **Optimized Thompson Sampling** (default frontend + processor.py): Reads nvext.annotations
+    - **Optimized Thompson Sampling** (default frontend + processor.py): Reads nvext.agent_hints
 
     To disable prefix hints, set prefix_template to null/None in your config.
     """
@@ -341,7 +341,7 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     prediction_trie_path: str | None = Field(
         default=None,
         description="Path to prediction_trie.json file. When set, predictions are "
-        "looked up and used to override both HTTP headers and nvext.annotations for each LLM call.",
+        "looked up and used to override both HTTP headers and nvext.agent_hints for each LLM call.",
     )
 
     # =========================================================================
@@ -383,14 +383,14 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
 
 class _DynamoTransport:
     """
-    Custom transport wrapper that injects both HTTP headers and nvext.annotations.
+    Custom transport wrapper that injects both HTTP headers and nvext.agent_hints.
 
     This approach is more reliable than event hooks because it modifies the request
     BEFORE httpx's internal state machine processes it. It supports both transport
     mechanisms simultaneously for maximum compatibility:
 
     - HTTP headers (x-prefix-*): For generalized Thompson Sampling setup
-    - nvext.annotations: For optimized Thompson Sampling setup (preferred)
+    - nvext.agent_hints: For optimized Thompson Sampling setup (preferred)
     """
 
     def __init__(
@@ -468,45 +468,42 @@ class _DynamoTransport:
         headers[f"{LLMHeaderPrefix.DYNAMO.value}-osl"] = osl
         headers[f"{LLMHeaderPrefix.DYNAMO.value}-iat"] = iat
 
-        # Modify body to inject nvext.annotations (if JSON POST request)
+        # Modify body to inject nvext.agent_hints (if JSON POST request)
         content = request.content
         if request.method == "POST" and content:
             try:
                 body = json.loads(content.decode("utf-8", errors="replace"))
                 if isinstance(body, dict):
-                    # Build annotations list
-                    annotations = [
-                        f"prefix_id:{prefix_id}",
-                        f"total_requests:{total_requests}",
-                        f"osl:{osl}",
-                        f"iat:{iat}",
-                    ]
+                    # Build agent_hints dict
+                    agent_hints = {
+                        "prefix_id": prefix_id,
+                        "total_requests": total_requests,
+                        "osl": osl,
+                        "iat": iat,
+                    }
 
-                    # Add/merge nvext.annotations
+                    # Add/merge nvext.agent_hints
                     if "nvext" not in body:
                         body["nvext"] = {}
                     if not isinstance(body["nvext"], dict):
                         body["nvext"] = {}
 
-                    existing = body["nvext"].get("annotations", [])
-                    if not isinstance(existing, list):
-                        existing = []
+                    existing = body["nvext"].get("agent_hints", {})
+                    if not isinstance(existing, dict):
+                        existing = {}
 
-                    # Our annotations take precedence
-                    body["nvext"]["annotations"] = annotations + [
-                        a for a in existing
-                        if not any(a.startswith(f"{key}:") for key in ["prefix_id", "total_requests", "osl", "iat"])
-                    ]
+                    # Our hints take precedence over existing
+                    body["nvext"]["agent_hints"] = {**existing, **agent_hints}
 
                     # Re-encode
                     content = json.dumps(body).encode("utf-8")
                     headers["content-length"] = str(len(content))
 
-                    logger.debug("Injected nvext.annotations: %s (body size: %d bytes)",
-                                 body["nvext"]["annotations"],
+                    logger.debug("Injected nvext.agent_hints: %s (body size: %d bytes)",
+                                 body["nvext"]["agent_hints"],
                                  len(content))
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                logger.debug("Could not inject nvext.annotations: %s", e)
+                logger.debug("Could not inject nvext.agent_hints: %s", e)
 
         # Create new request with modified headers and content
         new_request = httpx.Request(
@@ -548,10 +545,10 @@ def create_httpx_client_with_dynamo_hooks(
 
     This client can be passed to the OpenAI SDK to inject hints at the HTTP level,
     making it framework-agnostic. Hints are injected via both HTTP headers and
-    nvext.annotations in the request body for maximum compatibility:
+    nvext.agent_hints in the request body for maximum compatibility:
 
     - HTTP headers (x-prefix-*): For generalized Thompson Sampling setup
-    - nvext.annotations: For optimized Thompson Sampling setup (preferred)
+    - nvext.agent_hints: For optimized Thompson Sampling setup (preferred)
 
     Args:
         prefix_template: Template string with {uuid} placeholder (unused, kept for API compat)

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
@@ -236,8 +236,8 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    async def test_prediction_overrides_both_headers_and_annotations(self, sample_trie_lookup):
-        """Test that predictions override both HTTP headers AND nvext.annotations."""
+    async def test_prediction_overrides_both_headers_and_agent_hints(self, sample_trie_lookup):
+        """Test that predictions override both HTTP headers AND nvext.agent_hints."""
         # Create mock base transport
         mock_response = httpx.Response(200, json={"result": "ok"})
         mock_transport = MagicMock()
@@ -277,11 +277,11 @@ class TestDynamicPredictionTransport:
                 assert modified_request.headers[f"{prefix}-osl"] == "LOW"
                 assert modified_request.headers[f"{prefix}-iat"] == "HIGH"
 
-                # Verify annotations
+                # Verify agent_hints
                 body = json.loads(modified_request.content.decode("utf-8"))
-                annotations = body["nvext"]["annotations"]
-                assert "total_requests:3" in annotations
-                assert "osl:LOW" in annotations
-                assert "iat:HIGH" in annotations
+                agent_hints = body["nvext"]["agent_hints"]
+                assert agent_hints["total_requests"] == 3
+                assert agent_hints["osl"] == "LOW"
+                assert agent_hints["iat"] == "HIGH"
 
         DynamoPrefixContext.clear()

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -351,8 +351,8 @@ class TestDynamoTransport:
         # Cleanup
         DynamoPrefixContext.clear()
 
-    async def test_transport_injects_nvext_annotations(self):
-        """Test that _DynamoTransport injects nvext.annotations in request body."""
+    async def test_transport_injects_nvext_agent_hints(self):
+        """Test that _DynamoTransport injects nvext.agent_hints in request body."""
         import json
 
         import httpx
@@ -394,21 +394,21 @@ class TestDynamoTransport:
         # Parse the modified body
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        # Verify nvext.annotations was injected
+        # Verify nvext.agent_hints was injected
         assert "nvext" in body
-        assert "annotations" in body["nvext"]
-        annotations = body["nvext"]["annotations"]
+        assert "agent_hints" in body["nvext"]
+        agent_hints = body["nvext"]["agent_hints"]
 
-        assert "prefix_id:eval-q001" in annotations
-        assert "total_requests:10" in annotations
-        assert "osl:MEDIUM" in annotations
-        assert "iat:HIGH" in annotations
+        assert agent_hints["prefix_id"] == "eval-q001"
+        assert agent_hints["total_requests"] == 10
+        assert agent_hints["osl"] == "MEDIUM"
+        assert agent_hints["iat"] == "HIGH"
 
         # Cleanup
         DynamoPrefixContext.clear()
 
-    async def test_transport_merges_existing_annotations(self):
-        """Test that existing nvext.annotations are preserved (non-conflicting)."""
+    async def test_transport_merges_existing_agent_hints(self):
+        """Test that existing nvext.agent_hints are preserved (non-conflicting)."""
         import json
 
         import httpx
@@ -429,14 +429,14 @@ class TestDynamoTransport:
 
         DynamoPrefixContext.set("merge-test")
 
-        # Create request with existing nvext.annotations
+        # Create request with existing nvext.agent_hints
         original_body = {
             "model": "test",
             "nvext": {
-                "annotations": [
-                    "custom_key:custom_value",
-                    "iat:SHOULD_BE_REPLACED",  # Should be overridden
-                ]
+                "agent_hints": {
+                    "custom_key": "custom_value",
+                    "iat": "SHOULD_BE_REPLACED",  # Should be overridden
+                }
             }
         }
         request = httpx.Request("POST", "https://api.example.com/chat", json=original_body)
@@ -448,19 +448,19 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        annotations = body["nvext"]["annotations"]
+        agent_hints = body["nvext"]["agent_hints"]
 
-        # Our annotations should be first
-        assert annotations[0] == "prefix_id:merge-test"
-        assert annotations[1] == "total_requests:5"
-        assert annotations[2] == "osl:LOW"
-        assert annotations[3] == "iat:MEDIUM"
+        # Our hints should be present
+        assert agent_hints["prefix_id"] == "merge-test"
+        assert agent_hints["total_requests"] == 5
+        assert agent_hints["osl"] == "LOW"
+        assert agent_hints["iat"] == "MEDIUM"
 
-        # Custom annotation preserved
-        assert "custom_key:custom_value" in annotations
+        # Custom hint preserved
+        assert agent_hints["custom_key"] == "custom_value"
 
-        # Old conflicting annotation should NOT be present
-        assert "iat:SHOULD_BE_REPLACED" not in annotations
+        # Old conflicting hint should be overridden
+        assert agent_hints["iat"] == "MEDIUM"
 
         DynamoPrefixContext.clear()
 
@@ -550,14 +550,14 @@ class TestDynamoTransport:
         assert modified_request.headers[f"{prefix}-osl"] == "HIGH"  # from prediction (2500 tokens)
         assert modified_request.headers[f"{prefix}-iat"] == "LOW"  # from prediction (50ms)
 
-        # Verify prediction values also used in nvext.annotations
+        # Verify prediction values also used in nvext.agent_hints
         import json
         body = json.loads(modified_request.content.decode("utf-8"))
-        annotations = body["nvext"]["annotations"]
+        agent_hints = body["nvext"]["agent_hints"]
 
-        assert "total_requests:25" in annotations
-        assert "osl:HIGH" in annotations
-        assert "iat:LOW" in annotations
+        assert agent_hints["total_requests"] == 25
+        assert agent_hints["osl"] == "HIGH"
+        assert agent_hints["iat"] == "LOW"
 
         # Verify lookup was called
         assert mock_lookup.find.called


### PR DESCRIPTION
Move prefix hints (prefix_id, total_requests, osl, iat) from nvext.annotations (list of "key:value" strings) to nvext.agent_hints (dict). This gives a cleaner structure and separates agent hints from other annotation data.

https://claude.ai/code/session_01XSguCrvFEww79S6VA3coNC

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
